### PR TITLE
doc: fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ There are already so many [great plugins](#other-surround-plugins) for surroundi
 
 1. Install the plugin with your favorite plugin manager.
 
-2. All it does is expose one function, which you can map to whatever key you'd like. In this example, I use shift+s (S):
+2. All it does is expose one function, which you can map to whatever key you'd like. In this example, I use <kbd>shift+s</kbd> (<kbd>S</kbd>):
 
 ```lua
-vim.keymap.set("v", "S", require("multichar-surround").do_surround)
+vim.keymap.set("v", "S", function() require("multichar-surround").do_surround() end)
 ```
 
 The following does both of the above steps if you're using [lazy.nvim](https://github.com/folke/lazy.nvim):
@@ -25,30 +25,55 @@ The following does both of the above steps if you're using [lazy.nvim](https://g
 ```lua
 {
     "cz875/multichar-surround.nvim",
-    config = function()
-        vim.keymap.set("v", "S", require("multichar-surround").do_surround))
-    end
+    keys = {
+        { mode = { "x" }, "S", function() require("multichar-surround").do_surround() end }
+    }
 }
 ```
 
-Once you've completed the above setup, you should be able to select some text in visual mode and edit its surrounding characters by pressing "S".
+Once you've completed the above setup, you should be able to select some text in visual mode and edit its surrounding characters by pressing <kbd>S</kbd>.
 
 # Configuration
 
-You can configure the plugin by passing a table to the `setup()` function. For example, if you wanted to redundantly override the default options with the default values:
+You can configure the plugin by passing a table to the `setup()` function.
+For example, if you wanted to redundantly override the default options with the default values:
 
 ```lua
 require("multichar-surround").setup({
     -- the text to show when prompting the user for input
-    prompt_text = "Edit right pair:", 
+    prompt_text = "Edit right pair:",
 
     -- a list of pairs of characters for the purposes of detecting and
     -- editing surrounding pairs
     matching_pairs = {
         { "(", ")" }, { "[", "]" }, { "{", "}" }, { "<", ">" }
     },
-})
+} --[[@as MulticharSurroundOpts]])
 ```
+
+In `lazy.nvim`, you can (and should) use the `opts` field:
+
+```lua
+{
+    "cz875/multichar-surround.nvim",
+    keys = {
+        { mode = { "x" }, "S", function() require("multichar-surround").do_surround() end }
+    },
+    ---@type MulticharSurroundOpts
+    opts = {
+        -- the text to show when prompting the user for input
+        prompt_text = "Edit right pair:",
+
+        -- a list of pairs of characters for the purposes of detecting and
+        -- editing surrounding pairs
+        matching_pairs = {
+            { "(", ")" }, { "[", "]" }, { "{", "}" }, { "<", ">" }
+        },
+    }
+}
+```
+
+That opts table is then automatically passed into the `setup()` function.
 
 # Other surround plugins
 

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,6 +1,13 @@
 local M = {}
 
+---@class MulticharSurroundOpts
+---@field prompt_text string
+---An array of tuples; each tuple has two elements — the left delimiter and the right delimiter.
+---For example: `{ { "(", ")" }, { "[", "]" }, { "{", "}" }, { "<", ">" } }`.
+---@field matching_pairs [string, string][]
+
 -- default config
+---@type MulticharSurroundOpts
 M.config_table = {
   prompt_text = "Edit right pair:",
   matching_pairs = {
@@ -8,6 +15,7 @@ M.config_table = {
   },
 }
 
+---@param user_config_table MulticharSurroundOpts
 M.make_config = function(user_config_table)
   user_config_table = user_config_table or {}
   M.config_table = vim.tbl_deep_extend("force", M.config_table, user_config_table)


### PR DESCRIPTION
- **doc: suggest using `lazy.nvim` features in README**
- **doc: add `MulticharSurroundOpts` type for better lsp suggestions**

When you make a mapping directly to a `require`, it effectively loads the plugin at startup.
If you map it to a *function* that has that require, it correctly lazy loads the plugin.
The `keys` field lazy loads the plugin *and* creates the mapping, feeding 2 horses with three breadsticks.
I use `x` instead of `v`, because `v` includes select mode, that is used by luasnip's insert nodes.

I also add a class, so that people using neodev / lazydev can get lsp completions for the options of your plugin.
